### PR TITLE
added drush command to add a new notification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,12 @@
         "psr-4": {
             "Drupal\\Tests\\stanford_notifications\\": "./tests/src"
         }
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^9"
+            }
+        }
     }
 }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  stanford_notifications.commands:
+    class: \Drupal\stanford_notifications\Commands\StanfordNotificationsCommands
+    arguments: ['@notification_service']
+    tags:
+      - { name: drush.command }

--- a/src/Commands/StanfordNotificationsCommands.php
+++ b/src/Commands/StanfordNotificationsCommands.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\stanford_notifications\Commands;
+
+use Drupal\Core\Messenger\Messenger;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\stanford_notifications\NotificationServiceInterface;
+use Drush\Commands\DrushCommands;
+use Drush\Exceptions\UserAbortException;
+
+/**
+ * Class StanfordNotificationsCommands.
+ *
+ * @package Drupal\stanford_notifications\Commands
+ */
+class StanfordNotificationsCommands extends DrushCommands {
+
+  /**
+   * Notification service.
+   *
+   * @var \Drupal\stanford_notifications\NotificationServiceInterface
+   */
+  protected $notificationService;
+
+  /**
+   * StanfordNotificationsCommands constructor.
+   *
+   * @param \Drupal\stanford_notifications\NotificationServiceInterface $notificationService
+   *   Notification service.
+   */
+  public function __construct(NotificationServiceInterface $notificationService) {
+    $this->notificationService = $notificationService;
+  }
+
+  /**
+   * Add a new notification to users on the site.
+   *
+   * @param string $message
+   *   Notification message for the user.
+   * @param array $options
+   *   Keyed array of options
+   *
+   * @command stanford:add-notification
+   * @options roles Comma delimited list of roles to set the notification for.
+   * @options status Notification status type, 'status', 'warning', or 'error'.
+   *
+   * @throws \Drush\Exceptions\UserAbortException
+   */
+  public function addNotification($message, array $options = [
+    'roles' => '',
+    'status' => Messenger::TYPE_STATUS,
+  ]) {
+    $status_options = [Messenger::TYPE_STATUS, Messenger::TYPE_WARNING, Messenger::TYPE_ERROR];
+    if (!in_array($options['status'], $status_options)) {
+      throw new UserAbortException(new TranslatableMarkup('Invalid status. Please use one of the options: @options', ['@options' => implode(', ', $status_options)]));
+    }
+    $roles = explode(',', $options['roles']);
+    array_walk($roles, 'trim');
+    $this->notificationService->addNotification($message, array_filter($roles), $options['status']);
+  }
+
+}

--- a/src/Commands/StanfordNotificationsCommands.php
+++ b/src/Commands/StanfordNotificationsCommands.php
@@ -38,7 +38,7 @@ class StanfordNotificationsCommands extends DrushCommands {
    * @param string $message
    *   Notification message for the user.
    * @param array $options
-   *   Keyed array of options
+   *   Keyed array of options.
    *
    * @command stanford:add-notification
    * @options roles Comma delimited list of roles to set the notification for.
@@ -50,7 +50,12 @@ class StanfordNotificationsCommands extends DrushCommands {
     'roles' => '',
     'status' => Messenger::TYPE_STATUS,
   ]) {
-    $status_options = [Messenger::TYPE_STATUS, Messenger::TYPE_WARNING, Messenger::TYPE_ERROR];
+    $status_options = [
+      Messenger::TYPE_STATUS,
+      Messenger::TYPE_WARNING,
+      Messenger::TYPE_ERROR,
+    ];
+
     if (!in_array($options['status'], $status_options)) {
       throw new UserAbortException(new TranslatableMarkup('Invalid status. Please use one of the options: @options', ['@options' => implode(', ', $status_options)]));
     }

--- a/tests/src/Kernel/Commands/StanfordNotificationsCommandsTest.php
+++ b/tests/src/Kernel/Commands/StanfordNotificationsCommandsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\Tests\stanford_notifications\Kernel\Commands;
+
+use Drupal\stanford_notifications\Commands\StanfordNotificationsCommands;
+use Drupal\Tests\stanford_notifications\Kernel\StanfordNotificationTestBase;
+use Drush\Exceptions\UserAbortException;
+
+/**
+ * Class StanfordNotificationsCommandsTest.
+ *
+ * @group stanford_notifications
+ * @coversDefaultClass \Drupal\stanford_notifications\Commands\StanfordNotificationsCommands
+ */
+class StanfordNotificationsCommandsTest extends StanfordNotificationTestBase {
+
+  /**
+   * Drush command should make some entities.
+   */
+  public function testAddDrushCommand() {
+    $this->createUser();
+    $commands = new StanfordNotificationsCommands(\Drupal::service('notification_service'));
+    $commands->addNotification('Foo Bar');
+    $notifications = \Drupal::entityTypeManager()->getStorage('notification')->loadMultiple();
+    $this->assertCount(1, $notifications);
+
+    $this->expectException(UserAbortException::class);
+    $commands->addNotification('Foo', ['status' => 'foo']);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a drush command to add a notification.

# Need Review By (Date)
- Much later. no rush

# Urgency
- VERY low

# Steps to Test
1. checkout this branch
1. clear caches
1. try `drush stanford:add-notification 'Some message'`
1. verify the notification was created in the UI
1. options include `--roles=roles_1,role_2` and `--status=warning`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
